### PR TITLE
Close window after processing when called from macro

### DIFF
--- a/JACoP_/src/JACoP_.java
+++ b/JACoP_/src/JACoP_.java
@@ -38,6 +38,7 @@ public class JACoP_ implements PlugIn{
         	frame.setVisible(true);;
         }else{
             frame.doZeJob(false);
+            frame.dispose();
         }
 		
 	}


### PR DESCRIPTION
I had a friend ask for help, as they had the problem of processing a huge number of images with this plugin from a macro and afterward had to close all created plugin windows manually.

I tried another approach (that mimics the `if` branch where the GUI is directly opened) with `setVisible(false)`, but apparently some of the processing code fails if the window is not visible. So disposing of the window after processing was done was the next-best solution.

For any people that would also want to use this fixed I published the installable `.jar` here: https://github.com/hobofan/IJ-Plugin_JACoP/releases/tag/macro-window-close-fix