### PR TITLE
bugfix for white dots in cytofluorogram

### DIFF
--- a/JACoP_/src/_JACoP/ImageColocalizer.java
+++ b/JACoP_/src/_JACoP/ImageColocalizer.java
@@ -398,7 +398,7 @@ public class ImageColocalizer {
         double limHigh=Math.max(this.Amax, this.Bmax);
         double limLow=Math.min(this.Amin, this.Bmin);
         plot.setLimits(this.Amin, this.Amax, this.Bmin, this.Bmax);
-        plot.setColor(Color.white);
+        plot.setColor(Color.black);
         
         this.doThat=true;
         double[] tmp=linreg(this.A, this.B, 0, 0);


### PR DESCRIPTION
Hi @fabricecordelieres,

The cytofluorogram displays white dots on a white background since long time. This should fix it. 
Let me  know if there is actually a newer version of repository of JACoP. I would like to avoid that the plugin is getting abandoned since I think it is still one of the most user friendliest and helpful co-localization tool in Fiji